### PR TITLE
Force SeuratObject >=5.0.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,7 +12,7 @@ Depends:
     R (>= 4.2.0)
 Imports:
     Seurat,
-    SeuratObject,
+    SeuratObject (>= 5.0.0),
     dplyr,
     tidyr,
     naturalsort,


### PR DESCRIPTION
cellhashR internally uses Layers() and other functions required from SeuratObject >5